### PR TITLE
Support $Exact type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,21 @@
 {
   "parser": "babel-eslint",
-  "extends": "airbnb",
+  "extends": [
+    "airbnb",
+    "prettier",
+    "prettier/flowtype",
+    "plugin:flowtype/recommended"
+  ],
+  "plugins": ["prettier", "flowtype"],
   "env": {
+    "es6": true,
     "jest": true
   },
   "rules": {
-    "quotes": [
-      "error",
-      "double"
-    ],
+    "quotes": ["error", "double"],
     "comma-dangle": "off",
-    "no-console": "off"
+    "no-console": "off",
+    "prettier/prettier": "error",
+    "curly": 0
   }
 }

--- a/__tests__/__mocks__/exact/expected.json.flow.js
+++ b/__tests__/__mocks__/exact/expected.json.flow.js
@@ -1,0 +1,6 @@
+// @flow
+export type Pet = {| id: number |} & NewPet;
+export type NewPet = {| name: string, tag: string, category: Category |};
+export type ErrorModel = {| code: number, message: string |};
+export type IGenericCollectionPet = {| items: Array<Pet> |};
+export type IGenericCollectionString = {| items: Array<string> |};

--- a/__tests__/__mocks__/exact/expected.yaml.flow.js
+++ b/__tests__/__mocks__/exact/expected.yaml.flow.js
@@ -1,0 +1,32 @@
+// @flow
+export type Order = {|
+  id: number,
+  petId: number,
+  quantity: number,
+  shipDate: string,
+  status: string,
+  complete: boolean
+|};
+export type Category = {| id: number, name: string |};
+export type User = {|
+  id: number,
+  username: string,
+  firstName: string,
+  lastName: string,
+  email: string,
+  password: string,
+  phone: string,
+  userStatus: number
+|};
+export type Tag = {| id: number, name: string |};
+export type Pet = {|
+  id: number,
+  category: Category,
+  name: string,
+  photoUrls: Array<string>,
+  tags: Array<Tag>,
+  status: string
+|};
+export type IGenericCollectionPet = {| items: Array<Pet> |};
+export type IGenericCollectionString = {| items: Array<string> |};
+export type ApiResponse = {| code: number, type: string, message: string |};

--- a/__tests__/checkRequired.test.js
+++ b/__tests__/checkRequired.test.js
@@ -2,28 +2,34 @@ import fs from "fs";
 import path from "path";
 import { FlowTypeGenerator, generator } from "../src/index";
 
-jest.mock('commander', () => {
+jest.mock("commander", () => {
   return {
     checkRequired: true,
     arguments: jest.fn().mockReturnThis(),
     option: jest.fn().mockReturnThis(),
     action: jest.fn().mockReturnThis(),
-    parse: jest.fn().mockReturnThis(),
-  }
+    parse: jest.fn().mockReturnThis()
+  };
 });
 
 describe("generate flow types", () => {
   describe("with --check-required", () => {
     it("should generate expected flow types", () => {
       const file = path.join(__dirname, "__mocks__/swagger.yaml");
-      const expected = path.join(__dirname, "__mocks__/checkRequired/expected.yaml.flow.js");
+      const expected = path.join(
+        __dirname,
+        "__mocks__/checkRequired/expected.yaml.flow.js"
+      );
       const expectedString = fs.readFileSync(expected, "utf8");
       expect(generator(file)).toEqual(expectedString);
     });
 
     it("should generate expected flow types from swagger.json", () => {
       const file = path.join(__dirname, "__mocks__/swagger.json");
-      const expected = path.join(__dirname, "__mocks__/checkRequired/expected.json.flow.js");
+      const expected = path.join(
+        __dirname,
+        "__mocks__/checkRequired/expected.json.flow.js"
+      );
       const expectedString = fs.readFileSync(expected, "utf8");
       expect(generator(file)).toEqual(expectedString);
     });

--- a/__tests__/exact.test.js
+++ b/__tests__/exact.test.js
@@ -1,0 +1,35 @@
+import fs from "fs";
+import path from "path";
+import { generator } from "../src/index";
+
+jest.mock("commander", () => ({
+  exact: true,
+  arguments: jest.fn().mockReturnThis(),
+  option: jest.fn().mockReturnThis(),
+  action: jest.fn().mockReturnThis(),
+  parse: jest.fn().mockReturnThis()
+}));
+
+describe("generate flow types", () => {
+  describe("with --exact", () => {
+    it("should generate expected flow types", () => {
+      const file = path.join(__dirname, "__mocks__/swagger.yaml");
+      const expected = path.join(
+        __dirname,
+        "__mocks__/exact/expected.yaml.flow.js"
+      );
+      const expectedString = fs.readFileSync(expected, "utf8");
+      expect(generator(file)).toEqual(expectedString);
+    });
+
+    it("should generate expected flow types from swagger.json", () => {
+      const file = path.join(__dirname, "__mocks__/swagger.json");
+      const expected = path.join(
+        __dirname,
+        "__mocks__/exact/expected.json.flow.js"
+      );
+      const expectedString = fs.readFileSync(expected, "utf8");
+      expect(generator(file)).toEqual(expectedString);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "js-yaml": "^3.8.4",
-    "prettier": "^1.4.4"
+    "prettier": "^1.5.3"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -42,8 +42,11 @@
     "babel-preset-flow": "^6.23.0",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.0.1",
+    "eslint-config-prettier": "^2.3.0",
+    "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-jsx-a11y": "^5.0.3",
+    "eslint-plugin-prettier": "^2.1.2",
     "eslint-plugin-react": "^7.1.0",
     "flow-bin": "^0.48.0",
     "jest": "^20.0.4"

--- a/src/index.js
+++ b/src/index.js
@@ -85,20 +85,20 @@ const propertiesList = (definition: Object) => {
 };
 
 const withExact = (property: string): string => {
-  return property.replace(/{/g, "{|").replace(/}/g, "|}");
+  const result = property.replace(/{/g, "{|").replace(/}/g, "|}");
+  return result;
 };
 
 const propertiesTemplate = (properties: Object | Array<Object>): string => {
   if (Array.isArray(properties)) {
     return properties
-      .map(
-        property =>
-          property.$ref
-            ? `& ${property.$ref}`
-            : program.exact
-              ? withExact(JSON.stringify(property))
-              : JSON.stringify(property)
-      )
+      .map(property => {
+        let p = property.$ref ? `& ${property.$ref}` : JSON.stringify(property);
+        if (!property.$ref && program.exact) {
+          p = withExact(p);
+        }
+        return p;
+      })
       .sort(a => (a[0] === "&" ? 1 : -1))
       .join(" ");
   }

--- a/src/index.js
+++ b/src/index.js
@@ -84,15 +84,26 @@ const propertiesList = (definition: Object) => {
   );
 };
 
+const withExact = (property: string): string => {
+  return property.replace(/{/g, "{|").replace(/}/g, "|}");
+};
+
 const propertiesTemplate = (properties: Object | Array<Object>): string => {
   if (Array.isArray(properties)) {
     return properties
       .map(
         property =>
-          property.$ref ? `& ${property.$ref}` : JSON.stringify(property)
+          property.$ref
+            ? `& ${property.$ref}`
+            : program.exact
+              ? withExact(JSON.stringify(property))
+              : JSON.stringify(property)
       )
       .sort(a => (a[0] === "&" ? 1 : -1))
       .join(" ");
+  }
+  if (program.exact) {
+    return withExact(JSON.stringify(properties));
   }
   return JSON.stringify(properties);
 };
@@ -143,6 +154,7 @@ program
   .arguments("<file>")
   .option("-d --destination <destination>", "Destination path")
   .option("-cr --check-required", "Add question mark to optional properties")
+  .option("-e --exact", "Add exact types")
   .action(file => {
     try {
       const result = generator(file);

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const typeMapping = {
   number: "number",
   null: "null",
   object: "Object",
-  "Object": "Object",
+  Object: "Object",
   string: "string",
   enum: "string"
 };
@@ -23,93 +23,114 @@ const definitionTypeName = (ref): string => {
   const re = /#\/definitions\/(.*)/;
   const found = ref.match(re);
   return found ? found[1] : "";
-}
+};
 
-const stripBrackets = (name: string) => name.replace(/[\[\]']+/g, '')
+const stripBrackets = (name: string) => name.replace(/[[\]']+/g, "");
 
 const typeFor = (property: any): string => {
-  if (property.type === 'array') {
+  if (property.type === "array") {
     if ("$ref" in property.items) {
       return `Array<${definitionTypeName(property.items.$ref)}>`;
-    } else {
-      return `Array<${typeMapping[property.items.type]}>`;
     }
-  } else {
-    return typeMapping[property.type] || definitionTypeName(property.$ref);
+    return `Array<${typeMapping[property.items.type]}>`;
   }
-}
+  return typeMapping[property.type] || definitionTypeName(property.$ref);
+};
 
 const isRequired = (propertyName: string, definition: Object): boolean => {
-  return definition.required && definition.required.indexOf(propertyName) >= 0;
-}
+  const result =
+    definition.required && definition.required.indexOf(propertyName) >= 0;
+  return result;
+};
 
-const propertyKeyForDefinition = (propName: string, definition: Object): string => {
+const propertyKeyForDefinition = (
+  propName: string,
+  definition: Object
+): string => {
   if (program.checkRequired) {
-    return `${propName}${isRequired(propName, definition) ? '' : '?'}`;
-  } else {
-    return propName;
+    return `${propName}${isRequired(propName, definition) ? "" : "?"}`;
   }
-}
+  return propName;
+};
 
 const propertiesList = (definition: Object) => {
-  if("allOf" in definition) {
+  if ("allOf" in definition) {
     return definition.allOf.map(propertiesList);
   }
 
-  if(definition.$ref) {
-    return {$ref: definitionTypeName(definition.$ref)};
-  } else {
-    if (!definition.properties || Object.keys(definition.properties).length === 0) {
-      return {};
-    } else {
-      return Object.assign.apply(null,
-        Object.keys(definition.properties)
-          .reduce((properties: Array<Object>, propName: string) => {
-            return properties.concat({
-              [propertyKeyForDefinition(propName, definition)]: typeFor(definition.properties[propName])
-            })
-          }, [{}])
-      )
-    }
+  if (definition.$ref) {
+    return { $ref: definitionTypeName(definition.$ref) };
   }
-}
+
+  if (
+    !definition.properties ||
+    Object.keys(definition.properties).length === 0
+  ) {
+    return {};
+  }
+  return Object.assign.apply(
+    null,
+    Object.keys(definition.properties).reduce(
+      (properties: Array<Object>, propName: string) => {
+        const arr = properties.concat({
+          [propertyKeyForDefinition(propName, definition)]: typeFor(
+            definition.properties[propName]
+          )
+        });
+        return arr;
+      },
+      [{}]
+    )
+  );
+};
 
 const propertiesTemplate = (properties: Object | Array<Object>): string => {
   if (Array.isArray(properties)) {
     return properties
-      .map((property) => property.$ref ? `& ${property.$ref}` : JSON.stringify(property))
-      .sort((a, b) => a[0] === '&' ? 1 : -1)
-      .join(' ')
-  } else {
-    return JSON.stringify(properties)
+      .map(
+        property =>
+          property.$ref ? `& ${property.$ref}` : JSON.stringify(property)
+      )
+      .sort(a => (a[0] === "&" ? 1 : -1))
+      .join(" ");
   }
-}
+  return JSON.stringify(properties);
+};
 
 const generate = (swagger: Object) => {
-  return Object.keys(swagger.definitions)
+  const g = Object.keys(swagger.definitions)
     .reduce((acc: Array<Object>, definitionName: string) => {
-      return acc.concat({
+      const arr = acc.concat({
         title: stripBrackets(definitionName),
         properties: propertiesList(swagger.definitions[definitionName])
-      })
+      });
+      return arr;
     }, [])
-    .map((definition) => {
-      return `export type ${definition.title} = ${propertiesTemplate(definition.properties).replace(/\"/g, '')};`
-      }
-    ).join(' ')
-}
+    .map(definition => {
+      const s = `export type ${definition.title} = ${propertiesTemplate(
+        definition.properties
+      ).replace(/"/g, "")};`;
+      return s;
+    })
+    .join(" ");
+  return g;
+};
 
 export const generator = (file: string) => {
-  const doc: Object = path.extname(file) === ".yaml"
-    ? yaml.safeLoad(fs.readFileSync(file, "utf8"))
-    : JSON.parse(fs.readFileSync(file, "utf8"));
+  const ext = path.extname(file);
+  let doc;
+  if (ext === ".yaml") {
+    doc = yaml.safeLoad(fs.readFileSync(file, "utf8"));
+  } else {
+    doc = JSON.parse(fs.readFileSync(file, "utf8"));
+  }
   const options = {};
-  const result = `// @flow\n${generate(doc)}`
+  const result = `// @flow\n${generate(doc)}`;
   return prettier.format(result, options);
 };
 
 export const writeToFile = (dist: string = "./flowtype.js", result: string) => {
-  fs.writeFile(dist, result, (err) => {
+  fs.writeFile(dist, result, err => {
     if (err) {
       throw err;
     }
@@ -122,7 +143,7 @@ program
   .arguments("<file>")
   .option("-d --destination <destination>", "Destination path")
   .option("-cr --check-required", "Add question mark to optional properties")
-  .action((file) => {
+  .action(file => {
     try {
       const result = generator(file);
       const dist = distFile(program);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1147,6 +1147,12 @@ eslint-config-airbnb@^15.0.1:
   dependencies:
     eslint-config-airbnb-base "^11.2.0"
 
+eslint-config-prettier@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.3.0.tgz#b75b1eabea0c8b97b34403647ee25db349b9d8a0"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-import-resolver-node@^0.2.0:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
@@ -1161,6 +1167,12 @@ eslint-module-utils@^2.0.0:
   dependencies:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
+
+eslint-plugin-flowtype@^2.35.0:
+  version "2.35.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.35.0.tgz#d17494f0ae8b727c632d8b9d4b4a848e7e0c04af"
+  dependencies:
+    lodash "^4.15.0"
 
 eslint-plugin-import@^2.3.0:
   version "2.6.0"
@@ -1188,6 +1200,13 @@ eslint-plugin-jsx-a11y@^5.0.3:
     damerau-levenshtein "^1.0.0"
     emoji-regex "^6.1.0"
     jsx-ast-utils "^1.4.0"
+
+eslint-plugin-prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.1.2.tgz#4b90f4ee7f92bfbe2e926017e1ca40eb628965ea"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^20.0.1"
 
 eslint-plugin-react@^7.1.0:
   version "7.1.0"
@@ -1319,6 +1338,10 @@ extglob@^0.3.1:
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+
+fast-diff@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.1.tgz#0aea0e4e605b6a2189f0e936d4b7fbaf1b7cfd9b"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -1485,6 +1508,10 @@ generate-object-property@^1.1.0:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -1972,7 +1999,7 @@ jest-diff@^20.0.3:
     jest-matcher-utils "^20.0.3"
     pretty-format "^20.0.3"
 
-jest-docblock@^20.0.3:
+jest-docblock@^20.0.1, jest-docblock@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 
@@ -2269,7 +2296,7 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2604,9 +2631,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.4.4.tgz#a8d1447b14c9bf67e6d420dcadd10fb9a4fad65a"
+prettier@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
 
 pretty-format@^20.0.3:
   version "20.0.3"


### PR DESCRIPTION
Related to #8 
Add a `--exact` option to enable `$Exact type` into definitions. 
I also configured both `prettier` and `eslint` to format codes.