### PR TITLE
Support object in array

### DIFF
--- a/__tests__/__mocks__/objectInArray.flow.js
+++ b/__tests__/__mocks__/objectInArray.flow.js
@@ -1,0 +1,4 @@
+// @flow
+export type ObjectInArray = {
+  array: Array<{ requiredProp: string, optionalProp?: string }>
+};

--- a/__tests__/__mocks__/objectInArray.swagger.yaml
+++ b/__tests__/__mocks__/objectInArray.swagger.yaml
@@ -1,0 +1,17 @@
+definitions:
+  ObjectInArray:
+    type: "object"
+    required:
+      - array
+    properties:
+      array: 
+        type: array
+        items:
+          type: "object"
+          required:
+            - requiredProp
+          properties:
+            requiredProp:
+              type: string
+            optionalProp:
+              type: string

--- a/__tests__/objectInArray.test.js
+++ b/__tests__/objectInArray.test.js
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+import { FlowTypeGenerator, generator } from "../src/index";
+
+jest.mock('commander', () => {
+  return {
+    checkRequired: true,
+    arguments: jest.fn().mockReturnThis(),
+    option: jest.fn().mockReturnThis(),
+    action: jest.fn().mockReturnThis(),
+    parse: jest.fn().mockReturnThis(),
+  }
+});
+
+describe("generate flow types", () => {
+  describe("parse objct in array", () => {
+    it("should generate expected flow types", () => {
+      const file = path.join(__dirname, "__mocks__/objectInArray.swagger.yaml");
+      const expected = path.join(__dirname, "__mocks__/objectInArray.flow.js");
+      const expectedString = fs.readFileSync(expected, "utf8");
+      expect(generator(file)).toEqual(expectedString);
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,10 @@ const typeFor = (property: any): string => {
     if ("$ref" in property.items) {
       return `Array<${definitionTypeName(property.items.$ref)}>`;
     }
+    else if (property.items.type === 'object') {
+      const child = propertiesTemplate(propertiesList(property.items)).replace(/"/g, "");
+      return `Array<${child}>`;
+    }
     return `Array<${typeMapping[property.items.type]}>`;
   }
   return typeMapping[property.type] || definitionTypeName(property.$ref);


### PR DESCRIPTION
Support object in array property.

`swagger`

```
definitions:
  ObjectInArray:
    type: "object"
    required:
      - array
    properties:
      array: 
        type: array
        items:
          type: "object"
          required:
            - requiredProp
          properties:
            requiredProp:
              type: string
            optionalProp:
              type: string
```

Generate  `flow` file.

```
// @flow
export type ObjectInArray = {
  array: Array<{ requiredProp: string, optionalProp?: string }>
};
```
