### PR TITLE
Support non object type on root property

### DIFF
--- a/__tests__/__mocks__/enumOnRoot.flow.js
+++ b/__tests__/__mocks__/enumOnRoot.flow.js
@@ -1,0 +1,2 @@
+// @flow
+export type enumOnRoot = "hoge" | "piyo";

--- a/__tests__/__mocks__/enumOnRoot.swagger.yaml
+++ b/__tests__/__mocks__/enumOnRoot.swagger.yaml
@@ -1,0 +1,6 @@
+definitions:
+  enumOnRoot:
+    type: string
+    enum:
+      - hoge
+      - piyo

--- a/__tests__/enumOnRoot.test.js
+++ b/__tests__/enumOnRoot.test.js
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+import { FlowTypeGenerator, generator } from "../src/index";
+
+jest.mock('commander', () => {
+  return {
+    checkRequired: true,
+    arguments: jest.fn().mockReturnThis(),
+    option: jest.fn().mockReturnThis(),
+    action: jest.fn().mockReturnThis(),
+    parse: jest.fn().mockReturnThis(),
+  }
+});
+
+describe("generate flow types", () => {
+  describe("parse enum on root element", () => {
+    it("should generate expected flow types", () => {
+      const file = path.join(__dirname, "__mocks__/enumOnRoot.swagger.yaml");
+      const expected = path.join(__dirname, "__mocks__/enumOnRoot.flow.js");
+      const expectedString = fs.readFileSync(expected, "utf8");
+      expect(generator(file)).toEqual(expectedString);
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,10 @@ const propertiesList = (definition: Object) => {
     return { $ref: definitionTypeName(definition.$ref) };
   }
 
+  if ("type" in definition && definition.type !== "object") {
+    return typeFor(definition);
+  }
+
   if (
     !definition.properties ||
     Object.keys(definition.properties).length === 0
@@ -95,7 +99,10 @@ const withExact = (property: string): string => {
   return result;
 };
 
-const propertiesTemplate = (properties: Object | Array<Object>): string => {
+const propertiesTemplate = (properties: Object | Array<Object> | string): string => {
+  if (typeof properties === "string") {
+    return properties;
+  }
   if (Array.isArray(properties)) {
     return properties
       .map(property => {


### PR DESCRIPTION
Support convert non object type(enum, array,...) on root property.

Like below.

```yaml
definitions:
  enumOnRoot:
    type: string
    enum:
      - hoge
      - piyo
```

result

```js
export type enumOnRoot = "hoge" | "piyo";
```