### PR TITLE
Parse Error: Object in Array with extract option

### DIFF
--- a/__tests__/__mocks__/objectInArrayWithExact.flow.js
+++ b/__tests__/__mocks__/objectInArrayWithExact.flow.js
@@ -1,0 +1,4 @@
+// @flow
+export type ObjectInArray = {|
+  array: Array<{| requiredProp: string, optionalProp?: string |}>
+|};

--- a/__tests__/objectInArrayWithExact.test.js
+++ b/__tests__/objectInArrayWithExact.test.js
@@ -1,0 +1,25 @@
+import fs from "fs";
+import path from "path";
+import { generator } from "../src/index";
+
+jest.mock('commander', () => {
+  return {
+    exact: true,
+    checkRequired: true,
+    arguments: jest.fn().mockReturnThis(),
+    option: jest.fn().mockReturnThis(),
+    action: jest.fn().mockReturnThis(),
+    parse: jest.fn().mockReturnThis(),
+  }
+});
+
+describe("generate flow types", () => {
+  describe("parse objct in array", () => {
+    it("should generate expected flow types", () => {
+      const file = path.join(__dirname, "__mocks__/objectInArray.swagger.yaml");
+      const expected = path.join(__dirname, "__mocks__/objectInArrayWithExact.flow.js");
+      const expectedString = fs.readFileSync(expected, "utf8");
+      expect(generator(file)).toEqual(expectedString);
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ const propertiesList = (definition: Object) => {
 };
 
 const withExact = (property: string): string => {
-  const result = property.replace(/{/g, "{|").replace(/}/g, "|}");
+  const result = property.replace(/{[^|]/g, "{|").replace(/[^|]}/g, "|}");
   return result;
 };
 


### PR DESCRIPTION
Parse error of https://github.com/yayoc/swagger-to-flowtype/pull/12 with extract option.

Generated file is like following. Extract syntax (`|`) has duplicated.

```js
export type ObjectInArray = {|array:Array<{||requiredProp:string,optionalProp?:string||}>|};
```

Because `withExact` method called 2 times. I fixed that method will not convert `{|` and `|}`.