### PR TITLE
Implement mixed-type arrays

### DIFF
--- a/__tests__/__mocks__/mixedTypeArray.flow.js
+++ b/__tests__/__mocks__/mixedTypeArray.flow.js
@@ -1,0 +1,3 @@
+// @flow
+export type Cat = { id?: number };
+export type MixedTypeArray = Array<Cat | string>;

--- a/__tests__/__mocks__/mixedTypeArray.swagger.yaml
+++ b/__tests__/__mocks__/mixedTypeArray.swagger.yaml
@@ -1,0 +1,12 @@
+definitions:
+  Cat:
+    type: object
+    properties:
+      id:
+        type: integer
+  MixedTypeArray:
+    type: array
+    items:
+      oneOf:
+        - $ref: '#/definitions/Cat'
+        - type: string

--- a/__tests__/mixedTypeArray.test.js
+++ b/__tests__/mixedTypeArray.test.js
@@ -1,0 +1,27 @@
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+import { generator } from "../src/index";
+
+jest.mock("commander", () => ({
+  checkRequired: true,
+  arguments: jest.fn().mockReturnThis(),
+  option: jest.fn().mockReturnThis(),
+  action: jest.fn().mockReturnThis(),
+  parse: jest.fn().mockReturnThis()
+}));
+
+describe("generate flow types", () => {
+  describe("parse mixed-type array", () => {
+    it("should generate expected flow types", () => {
+      const file = path.join(
+        __dirname,
+        "__mocks__/mixedTypeArray.swagger.yaml"
+      );
+      const content = yaml.safeLoad(fs.readFileSync(file, "utf8"));
+      const expected = path.join(__dirname, "__mocks__/mixedTypeArray.flow.js");
+      const expectedString = fs.readFileSync(expected, "utf8");
+      expect(generator(content)).toEqual(expectedString);
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,16 @@ const stripBrackets = (name: string) => name.replace(/[[\]']+/g, "");
 
 const typeFor = (property: any): string => {
   if (property.type === "array") {
-    if ("$ref" in property.items) {
+    if ("oneOf" in property.items) {
+      return `Array<${property.items.oneOf
+        .map(
+          e =>
+            e.type === "object"
+              ? propertiesTemplate(propertiesList(e.items)).replace(/"/g, "")
+              : typeFor(e)
+        )
+        .join(" | ")}>`;
+    } else if ("$ref" in property.items) {
       return `Array<${definitionTypeName(property.items.$ref)}>`;
     } else if (property.items.type === "object") {
       const child = propertiesTemplate(propertiesList(property.items)).replace(


### PR DESCRIPTION
Use `oneOf` keyword to get an array type of mixed-type items.
https://swagger.io/docs/specification/data-models/data-types/#mixed-array