### PR TITLE
Allows property with dashes

### DIFF
--- a/__tests__/__mocks__/checkRequired/expected.json.flow.js
+++ b/__tests__/__mocks__/checkRequired/expected.json.flow.js
@@ -1,5 +1,5 @@
 // @flow
-export type Pet = { id: number } & NewPet;
+export type Pet = { id: number, "x-dashes-id"?: string } & NewPet;
 export type NewPet = { name: string, tag?: string, category?: Category };
 export type ErrorModel = { code: number, message: string };
 export type IGenericCollectionPet = { items?: Array<Pet> };

--- a/__tests__/__mocks__/checkRequired/expected.yaml.flow.js
+++ b/__tests__/__mocks__/checkRequired/expected.yaml.flow.js
@@ -21,6 +21,7 @@ export type User = {
 export type Tag = { id?: number, name?: string };
 export type Pet = {
   id?: number,
+  "x-dashes-id"?: string,
   category?: Category,
   name: string,
   photoUrls: Array<string>,

--- a/__tests__/__mocks__/exact/expected.json.flow.js
+++ b/__tests__/__mocks__/exact/expected.json.flow.js
@@ -1,5 +1,5 @@
 // @flow
-export type Pet = {| id: number |} & NewPet;
+export type Pet = {| id: number, "x-dashes-id": string |} & NewPet;
 export type NewPet = {| name: string, tag: string, category: Category |};
 export type ErrorModel = {| code: number, message: string |};
 export type IGenericCollectionPet = {| items: Array<Pet> |};

--- a/__tests__/__mocks__/exact/expected.yaml.flow.js
+++ b/__tests__/__mocks__/exact/expected.yaml.flow.js
@@ -21,6 +21,7 @@ export type User = {|
 export type Tag = {| id: number, name: string |};
 export type Pet = {|
   id: number,
+  "x-dashes-id": string,
   category: Category,
   name: string,
   photoUrls: Array<string>,

--- a/__tests__/__mocks__/expected.json.flow.js
+++ b/__tests__/__mocks__/expected.json.flow.js
@@ -1,5 +1,5 @@
 // @flow
-export type Pet = { id: number } & NewPet;
+export type Pet = { id: number, "x-dashes-id": string } & NewPet;
 export type NewPet = { name: string, tag: string, category: Category };
 export type ErrorModel = { code: number, message: string };
 export type IGenericCollectionPet = { items: Array<Pet> };

--- a/__tests__/__mocks__/expected.yaml.flow.js
+++ b/__tests__/__mocks__/expected.yaml.flow.js
@@ -21,6 +21,7 @@ export type User = {
 export type Tag = { id: number, name: string };
 export type Pet = {
   id: number,
+  "x-dashes-id": string,
   category: Category,
   name: string,
   photoUrls: Array<string>,

--- a/__tests__/__mocks__/mixedTypeArray.flow.js
+++ b/__tests__/__mocks__/mixedTypeArray.flow.js
@@ -1,3 +1,3 @@
 // @flow
-export type Cat = { id?: number };
+export type Cat = { id?: number, "x-dashes-id"?: string };
 export type MixedTypeArray = Array<Cat | string>;

--- a/__tests__/__mocks__/mixedTypeArray.swagger.yaml
+++ b/__tests__/__mocks__/mixedTypeArray.swagger.yaml
@@ -4,6 +4,8 @@ definitions:
     properties:
       id:
         type: integer
+      x-dashes-id:
+        type: string
   MixedTypeArray:
     type: array
     items:

--- a/__tests__/__mocks__/oas3.swagger.flow.js
+++ b/__tests__/__mocks__/oas3.swagger.flow.js
@@ -1,4 +1,9 @@
 // @flow
-export type Pet = { id: number, name: string, tag?: string };
+export type Pet = {
+  id: number,
+  name: string,
+  tag?: string,
+  "x-dashes-id": string
+};
 export type Pets = Array<Pet>;
 export type Error = { code: number, message: string };

--- a/__tests__/__mocks__/oas3.swagger.yaml
+++ b/__tests__/__mocks__/oas3.swagger.yaml
@@ -85,6 +85,7 @@ components:
       required:
         - id
         - name
+        - x-dashes-id
       properties:
         id:
           type: integer
@@ -92,6 +93,8 @@ components:
         name:
           type: string
         tag:
+          type: string
+        x-dashes-id:
           type: string
     Pets:
       type: array

--- a/__tests__/__mocks__/objectInArray.flow.js
+++ b/__tests__/__mocks__/objectInArray.flow.js
@@ -1,4 +1,9 @@
 // @flow
 export type ObjectInArray = {
-  array: Array<{ requiredProp: string, optionalProp?: string }>
+  array: Array<{
+    requiredProp: string,
+    "x-dashes-id": string,
+    optionalProp?: string,
+    "x-dashes-optional-id"?: string
+  }>
 };

--- a/__tests__/__mocks__/objectInArray.swagger.yaml
+++ b/__tests__/__mocks__/objectInArray.swagger.yaml
@@ -10,8 +10,13 @@ definitions:
           type: "object"
           required:
             - requiredProp
+            - x-dashes-id
           properties:
             requiredProp:
               type: string
+            x-dashes-id:
+              type: string
             optionalProp:
+              type: string
+            x-dashes-optional-id:
               type: string

--- a/__tests__/__mocks__/objectInArrayWithExact.flow.js
+++ b/__tests__/__mocks__/objectInArrayWithExact.flow.js
@@ -1,4 +1,9 @@
 // @flow
 export type ObjectInArray = {|
-  array: Array<{| requiredProp: string, optionalProp?: string |}>
+  array: Array<{|
+    requiredProp: string,
+    "x-dashes-id": string,
+    optionalProp?: string,
+    "x-dashes-optional-id"?: string
+  |}>
 |};

--- a/__tests__/__mocks__/propertyWithDashes.flow.js
+++ b/__tests__/__mocks__/propertyWithDashes.flow.js
@@ -1,0 +1,2 @@
+// @flow
+export type Cat = { "x-dashes-id"?: number };

--- a/__tests__/__mocks__/propertyWithDashes.swagger.yaml
+++ b/__tests__/__mocks__/propertyWithDashes.swagger.yaml
@@ -1,0 +1,6 @@
+definitions:
+  Cat:
+    type: object
+    properties:
+      x-dashes-id:
+        type: integer

--- a/__tests__/__mocks__/swagger.json
+++ b/__tests__/__mocks__/swagger.json
@@ -183,6 +183,9 @@
             "id": {
               "type": "integer",
               "format": "int64"
+            },
+            "x-dashes-id": {
+              "type": "string"
             }
           }
         }

--- a/__tests__/__mocks__/swagger.yaml
+++ b/__tests__/__mocks__/swagger.yaml
@@ -656,6 +656,8 @@ definitions:
       id:
         type: "integer"
         format: "int64"
+      x-dashes-id:
+        type: "string"
       category:
         $ref: "#/definitions/Category"
       name:

--- a/__tests__/propertyWithDashes.test.js
+++ b/__tests__/propertyWithDashes.test.js
@@ -1,0 +1,27 @@
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+import { generator } from "../src/index";
+
+jest.mock("commander", () => ({
+  checkRequired: true,
+  arguments: jest.fn().mockReturnThis(),
+  option: jest.fn().mockReturnThis(),
+  action: jest.fn().mockReturnThis(),
+  parse: jest.fn().mockReturnThis()
+}));
+
+describe("generate flow types", () => {
+  describe("parse property with dashes", () => {
+    it("should generate expected flow types", () => {
+      const file = path.join(
+        __dirname,
+        "__mocks__/propertyWithDashes.swagger.yaml"
+      );
+      const content = yaml.safeLoad(fs.readFileSync(file, "utf8"));
+      const expected = path.join(__dirname, "__mocks__/propertyWithDashes.flow.js");
+      const expectedString = fs.readFileSync(expected, "utf8");
+      expect(generator(content)).toEqual(expectedString);
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -68,10 +68,11 @@ const propertyKeyForDefinition = (
   propName: string,
   definition: Object
 ): string => {
+  const resolvedPropName = propName.indexOf("-") > 0 ? `'${propName}'` : propName;
   if (program.checkRequired) {
-    return `${propName}${isRequired(propName, definition) ? "" : "?"}`;
+    return `${resolvedPropName}${isRequired(propName, definition) ? "" : "?"}`;
   }
-  return propName;
+  return resolvedPropName;
 };
 
 const propertiesList = (definition: Object) => {


### PR DESCRIPTION
Fixes to #26 

In another pull request I will also make the build not OSX/UNIX dependant (it's using shell commands and not the cross-OS npm modules for deleting/creating dirs etc.)