### PR TITLE
Support for property type with array

### DIFF
--- a/__tests__/__mocks__/typeWithArray.flow.js
+++ b/__tests__/__mocks__/typeWithArray.flow.js
@@ -1,0 +1,2 @@
+// @flow
+export type Cat = { parentId: number | null };

--- a/__tests__/__mocks__/typeWithArray.swagger.yaml
+++ b/__tests__/__mocks__/typeWithArray.swagger.yaml
@@ -1,0 +1,10 @@
+definitions:
+  Cat:
+    type: object
+    properties:
+      parentId:
+        type:
+          - integer
+          - 'null'
+    required:
+      - parentId

--- a/__tests__/typeWithArray.test.js
+++ b/__tests__/typeWithArray.test.js
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+import { generator } from "../src/index";
+
+jest.mock("commander", () => ({
+  checkRequired: true,
+  arguments: jest.fn().mockReturnThis(),
+  option: jest.fn().mockReturnThis(),
+  action: jest.fn().mockReturnThis(),
+  parse: jest.fn().mockReturnThis()
+}));
+
+describe("generate flow types", () => {
+  describe("parse property with type array", () => {
+    it("should generate expected flow types", () => {
+      const file = path.join(__dirname, "__mocks__/typeWithArray.swagger.yaml");
+      const content = yaml.safeLoad(fs.readFileSync(file, "utf8"));
+      const expected = path.join(__dirname, "__mocks__/typeWithArray.flow.js");
+      const expectedString = fs.readFileSync(expected, "utf8");
+      expect(generator(content)).toEqual(expectedString);
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,8 @@ const typeFor = (property: any): string => {
     return `Array<${typeMapping[property.items.type]}>`;
   } else if (property.type === "string" && "enum" in property) {
     return property.enum.map(e => `'${e}'`).join(" | ");
+  } else if (Array.isArray(property.type)) {
+    return property.type.map(t => typeMapping[t]).join(" | ");
   }
   if ("allOf" in property) {
     return property.allOf.map(p => typeFor(p)).join("&");


### PR DESCRIPTION
According to the swagger spec, a property of a type can be an array.
The current implementation does not support that.
I've added a test with an example swagger file to the PR, please review it and let me know if I need to change something.