### PR TITLE
Using strict flow annotation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,7 @@ const generate = (swagger: Object): string => {
 
 export const generator = (content: Object, file: string) => {
   const options = prettier.resolveConfig.sync(file) || {};
-  const result = `// @flow\n${generate(content)}`;
+  const result = `// @flow strict\n${generate(content)}`;
   return prettier.format(result, options);
 };
 


### PR DESCRIPTION
I see no reason not to. The generated files should adhere to flow strict settings, if [strict] has been defined in .flowconfig.

https://flow.org/en/docs/strict/