### PR TITLE
Handling object type {} when using --exact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn-debug.log*
 yarn-error.log*
 coverage/
 .DS_Store
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 __tests__/
 node_modules/
 src/
+.idea

--- a/__tests__/__mocks__/checkRequired/expected.json.flow.js
+++ b/__tests__/__mocks__/checkRequired/expected.json.flow.js
@@ -1,5 +1,9 @@
 // @flow
-export type Pet = { id: number, "x-dashes-id"?: string } & NewPet;
+export type Pet = {
+  id: number,
+  "x-dashes-id"?: string,
+  objectType?: {}
+} & NewPet;
 export type NewPet = { name: string, tag?: string, category?: Category };
 export type ErrorModel = { code: number, message: string };
 export type IGenericCollectionPet = { items?: Array<Pet> };

--- a/__tests__/__mocks__/checkRequired/expected.yaml.flow.js
+++ b/__tests__/__mocks__/checkRequired/expected.yaml.flow.js
@@ -26,7 +26,8 @@ export type Pet = {
   name: string,
   photoUrls: Array<string>,
   tags?: Array<Tag>,
-  status?: "available" | "pending" | "sold"
+  status?: "available" | "pending" | "sold",
+  objectType?: {}
 };
 export type IGenericCollectionPet = { items?: Array<Pet> };
 export type IGenericCollectionString = { items?: Array<string> };

--- a/__tests__/__mocks__/exact/expected.json.flow.js
+++ b/__tests__/__mocks__/exact/expected.json.flow.js
@@ -1,5 +1,9 @@
 // @flow
-export type Pet = {| id: number, "x-dashes-id": string |} & NewPet;
+export type Pet = {|
+  id: number,
+  "x-dashes-id": string,
+  objectType: {}
+|} & NewPet;
 export type NewPet = {| name: string, tag: string, category: Category |};
 export type ErrorModel = {| code: number, message: string |};
 export type IGenericCollectionPet = {| items: Array<Pet> |};

--- a/__tests__/__mocks__/exact/expected.yaml.flow.js
+++ b/__tests__/__mocks__/exact/expected.yaml.flow.js
@@ -26,7 +26,8 @@ export type Pet = {|
   name: string,
   photoUrls: Array<string>,
   tags: Array<Tag>,
-  status: "available" | "pending" | "sold"
+  status: "available" | "pending" | "sold",
+  objectType: {}
 |};
 export type IGenericCollectionPet = {| items: Array<Pet> |};
 export type IGenericCollectionString = {| items: Array<string> |};

--- a/__tests__/__mocks__/expected.json.flow.js
+++ b/__tests__/__mocks__/expected.json.flow.js
@@ -1,5 +1,9 @@
 // @flow
-export type Pet = { id: number, "x-dashes-id": string } & NewPet;
+export type Pet = {
+  id: number,
+  "x-dashes-id": string,
+  objectType: {}
+} & NewPet;
 export type NewPet = { name: string, tag: string, category: Category };
 export type ErrorModel = { code: number, message: string };
 export type IGenericCollectionPet = { items: Array<Pet> };

--- a/__tests__/__mocks__/expected.yaml.flow.js
+++ b/__tests__/__mocks__/expected.yaml.flow.js
@@ -26,7 +26,8 @@ export type Pet = {
   name: string,
   photoUrls: Array<string>,
   tags: Array<Tag>,
-  status: "available" | "pending" | "sold"
+  status: "available" | "pending" | "sold",
+  objectType: {}
 };
 export type IGenericCollectionPet = { items: Array<Pet> };
 export type IGenericCollectionString = { items: Array<string> };

--- a/__tests__/__mocks__/swagger.json
+++ b/__tests__/__mocks__/swagger.json
@@ -186,6 +186,9 @@
             },
             "x-dashes-id": {
               "type": "string"
+            },
+            "objectType": {
+              "type": "object"
             }
           }
         }

--- a/__tests__/__mocks__/swagger.yaml
+++ b/__tests__/__mocks__/swagger.yaml
@@ -684,6 +684,9 @@ definitions:
         - "available"
         - "pending"
         - "sold"
+
+      objectType:
+        type: "object"
     xml:
       name: "Pet"
   IGenericCollection[Pet]:

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ const propertiesList = (definition: Object) => {
 };
 
 const withExact = (property: string): string => {
-  const result = property.replace(/{[^|]/g, "{|").replace(/[^|]}/g, "|}");
+  const result = property.replace(/{[^|}]/g, "{|").replace(/[^|{]}/g, "|}");
   return result;
 };
 


### PR DESCRIPTION
https://flow.org/en/docs/types/objects/#toc-object-type

Previously this would generate a type "{|" instead of "{}".