### PR TITLE
Replace bash-specific shell commands with cross platform shell commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Command line tool for generating flow types from swagger",
   "main": "./dist/index.js",
   "scripts": {
-    "init": "mkdir dist",
-    "clean": "rm -rf dist",
+    "init": "mkdirp dist",
+    "clean": "rimraf dist",
     "test": "jest",
     "test:watch": "jest --watch",
     "prebuild": "npm run clean && npm run init",
@@ -52,7 +52,8 @@
     "eslint-plugin-prettier": "^2.1.2",
     "eslint-plugin-react": "^7.1.0",
     "flow-bin": "^0.48.0",
-    "jest": "^20.0.4"
+    "jest": "^20.0.4",
+    "rimraf": "^2.6.2"
   },
   "jest": {
     "testRegex": "(/__tests__/[^__mocks__].*|(\\.|/)(test|spec))\\.jsx?$",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2900,6 +2900,13 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
+rimraf@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
+  dependencies:
+    glob "^7.0.5"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"


### PR DESCRIPTION
`rimraf` is an npm package that implements the `rm -rf` command across shell languages.

`mkdirp` is  already a dependency of the project, and implements the `mkdir -p` (which will make a directory, and if necessary the directory's parents) across shell languages.