### PR TITLE
doc: (README) Update the output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ export type Order = {
   petId: number,
   quantity: number,
   shipDate: string,
-  status: string,
+  status: 'placed' | 'approved' | 'delivered',
   complete: boolean
 };
 export type Category = { id: number, name: string };


### PR DESCRIPTION
Based on this line https://github.com/yayoc/swagger-to-flowtype/blob/master/src/index.js#L56 the output would contain enum types for enum fields.