### PR TITLE
Support additional properties

### DIFF
--- a/__tests__/__mocks__/additionalProperties.flow.js
+++ b/__tests__/__mocks__/additionalProperties.flow.js
@@ -1,0 +1,8 @@
+// @flow strict
+export type Simple = { [string]: string };
+export type Complex = {
+  [string]: { code?: number, text?: string },
+  name: string
+};
+export type Messages = { [string]: Message };
+export type Message = { code: number, text: string };

--- a/__tests__/__mocks__/additionalProperties.swagger.yaml
+++ b/__tests__/__mocks__/additionalProperties.swagger.yaml
@@ -1,0 +1,32 @@
+# examples are taken from https://swagger.io/docs/specification/data-models/dictionaries/
+definitions:
+  Simple:
+    type: object
+    additionalProperties:
+      type: string
+  Complex:
+    type: object
+    required: [ name ]
+    properties:
+      name:
+        type: string
+    additionalProperties:
+      type: object
+      properties:
+        code:
+          type: integer
+        text:
+          type: string
+  Messages:
+    type: object
+    additionalProperties:
+      $ref: '#/definitions/Message'
+  Message:
+    type: object
+    required: [ code, text ]
+    properties:
+      code:
+        type: integer
+      text:
+        type: string
+    additionalProperties: false

--- a/__tests__/additionalProperties.test.js
+++ b/__tests__/additionalProperties.test.js
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+import { generator } from "../src/index";
+
+jest.mock("commander", () => ({
+  checkRequired: true,
+  arguments: jest.fn().mockReturnThis(),
+  option: jest.fn().mockReturnThis(),
+  action: jest.fn().mockReturnThis(),
+  parse: jest.fn().mockReturnThis()
+}));
+
+describe("generate flow types", () => {
+  describe("parse additional properties", () => {
+    it("should generate expected flow types", () => {
+      const file = path.join(__dirname, "__mocks__/additionalProperties.swagger.yaml");
+      const content = yaml.safeLoad(fs.readFileSync(file, "utf8"));
+      const expected = path.join(__dirname, "__mocks__/additionalProperties.flow.js");
+      const expectedString = fs.readFileSync(expected, "utf8");
+      expect(generator(content)).toEqual(expectedString);
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -112,11 +112,16 @@ const propertiesList = (definition: Object) => {
     return typeFor(definition);
   }
 
+  let result = {};
+  if (definition.additionalProperties) {
+    result["[string]"] = typeFor(definition.additionalProperties);
+  }
+
   if (
     !definition.properties ||
     Object.keys(definition.properties).length === 0
   ) {
-    return {};
+    return result;
   }
   return Object.assign.apply(
     null,
@@ -130,7 +135,7 @@ const propertiesList = (definition: Object) => {
         });
         return arr;
       },
-      [{}]
+      [result]
     )
   );
 };


### PR DESCRIPTION
It'd be nice if this tool supports additional properties. There is another similar PR #59, but this PR also supports complex types and references.
(See also: https://github.com/jkawamoto/swagger-to-flowtype/blob/additionalProperties/__tests__/__mocks__/additionalProperties.swagger.yaml)

